### PR TITLE
Rewrite deindexing.md

### DIFF
--- a/docs/deindexing.md
+++ b/docs/deindexing.md
@@ -1,57 +1,56 @@
-# How to deindex/unlist/unpublish/block/remove your server's rooms from index
+<!--
+SPDX-FileCopyrightText: 2023 - 2024 Nikita Chernyi
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
 
-If your server publishes room directory over federation and has public rooms within the directory,
-they will appear in the search index after the next full reindex process (should be run daily).
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 
-Please keep in mind that to have a room indexed, you have to:
+# Deindexing: How to block your server's rooms from being indexed
 
-1. Explicitly mark a room federatable when creating it
-2. Explicitly mark a room as public in room settings
-3. Explicitly publish a room in the room directory
-4. Explicitly publish your room catalog over federation
+If your server publishes room directory over federation and its public rooms are listed on the directory, they will be included in the search index with daily full reindexing process. See [this page](indexing.md) for details about indexing.
 
-When you do all of those steps, you clearly understand the consequences of your decisions,
-i.e. a particular room that was made public, federatable,
-published in room catalog and then shared room catalog over federation will be accessed over federation.
+There are several ways to prevent rooms from being indexed. You can choose any of those methods per your needs and preference.
 
-MRS can't index a room if you didn't explicitly allow a room to be visible over federation.
-You either publish something over federation, or not.
-MRS is not a special thing, it uses the same API and the same set of rules as any other matrix server does.
+**Note**: if a room is public, federatable, and published on the room catalog which is shared over the federation, the room can be freely discovered and accessed over federation, whether by a MRS instance or not. **If the room is not accessible over federation, MRS does not add the room to the index**, strictly following and respecting the Matrix protocol.
 
-## unpublish your room directory from the federation
+## Methods to prevent rooms from being indexed
 
-If your server is indexed, that means you explicitly published your public rooms directory over federation.
-If you don't like that the information you explicitly published over federation is accessed over federation,
-you should consider unpublishing it.
+### Unpublish your room directory from the federation
 
-For synapse, you need to add the following config options in the `homeserver.yaml`:
+For indexing rooms, MRS only makes use of information on your public room directory which has been explicitly published on your homeserver. Note that the information is publicly available and basically anyone can retrieve that information.
+
+Therefore, it is expected protocol-wise to unpublish the room directory in order to prevent such information from being accessed altogether.
+
+For Synapse homeserver, add the following config options in the `homeserver.yaml`:
 
 ```yaml
 allow_public_rooms_over_federation: false
 ```
 
-in case of [etke.cc/ansible](https://github.com/etkecc/ansible) and [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy), add the following to your `vars.yml` configuration file:
+If you use [etke.cc/ansible](https://github.com/etkecc/ansible) and [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy) to manage your Matrix homeserver, add the following to your `vars.yml` configuration file:
 
 ```yaml
 matrix_synapse_allow_public_rooms_over_federation: false
 ```
 
-However, if you think that "publishing over federation, but not for that particular member of the federation" segregation is a good thing
-for Matrix protocol, MRS has several options to unlist/unpublish/block/remove your server and its rooms from indexing.
+As enabling the option unfederates your homeserver, *nobody* outside of the homeserver, including a MRS instance, can access to it over federation, making it technically impossible to index the rooms as a matter of course.
 
-## (specific room) using room topic
+### Add special strings to the room's topic
 
-As a room administrator/moderator, you could add special string to the room topic to prevent indexing:
+If you do want to make the server itself federated and the room directory to be published over the federation, only preventing rooms from being indexed, you can add special strings which instruct MRS instances not to index them.
+
+As a room administrator/moderator, you can add these strings to the room topic to prevent indexing:
 
 ```
 (MRS-noindex:true-MRS)
 ```
 
-[More details about room configuration](./room-configuration.md)
+See [this page](./room-configuration.md) for details about room configuration.
 
-## contact instance maintainers
+### Contact MRS instance maintainers
 
-MRS is open source project (code), it doesn't parse/index/process any data by itself, so you have to contact specific instance's maintainers.
-Each instance should have a page with details and contacts.
+If none of the methods described above is available (such as due to lack of permissions to edit the room's topic), you might try contacting to MRS instance's maintainers. On each instance should there be a page with contact details.
 
-That method is discouraged, because it requires manual intervention by instance's maintainers, and thus each request processing will take way more time than using any of the methods described above.
+We do not recommend this method, as it requires manual intervention by instance's maintainers, and thus it will take much more time for each request to be handled than those methods.
+
+⚠️ **Note**: MRS is open source project (code) which enables to set up MRS instances. *It is these instances which index rooms, not the project*, therefore it is not able for the team behind the project to deindex rooms from MRS instances.

--- a/docs/deindexing.md
+++ b/docs/deindexing.md
@@ -7,13 +7,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Deindexing: How to block your server's rooms from being indexed
 
-If your server publishes room directory over federation and its public rooms are listed on the directory, they will be included in the search index with daily full reindexing process. See [this page](indexing.md) for details about indexing.
+If your server publishes room directory over federation and its public rooms are listed on the directory, they will be included in the search index by Matrix Rooms Search (short: MRS) instances with daily full reindexing process.
+
+## (How indexing occurs)
+
+The rooms will be included in the search index, if these conditions are met:
+
+- The room was configured as federatable when you created it
+- The room is set to "public" in room settings
+- The room is published on your room directory
+- The room catalog is published over federation
+
+⚠️ **Note**: If those conditions are met, any rooms can be discovered and accessed over federation, *whether by a MRS instance or not*. Please note that MRS instances will index rooms purely by following and respecting the Matrix protocol. **They will never index rooms otherwise.** See [this page](indexing.md) for relevant similar information.
+
+## How to prevent rooms from being indexed
 
 There are several ways to prevent rooms from being indexed. You can choose any of those methods per your needs and preference.
-
-**Note**: if a room is public, federatable, and published on the room catalog which is shared over the federation, the room can be freely discovered and accessed over federation, whether by a MRS instance or not. **If the room is not accessible over federation, MRS does not add the room to the index**, strictly following and respecting the Matrix protocol.
-
-## Methods to prevent rooms from being indexed
 
 ### Unpublish your room directory from the federation
 

--- a/docs/deindexing.md
+++ b/docs/deindexing.md
@@ -26,7 +26,7 @@ There are several ways to prevent rooms from being indexed. You can choose any o
 
 ### Unpublish your room directory from the federation
 
-For indexing rooms, MRS only makes use of information on your public room directory which has been explicitly published on your homeserver. Note that the information is publicly available and basically anyone can retrieve that information.
+For indexing rooms, MRS only makes use of information on your public room directory which has been explicitly published by your homeserver. Note that the information is publicly available and basically any other Matrix server can retrieve that information.
 
 Therefore, it is expected protocol-wise to unpublish the room directory in order to prevent such information from being accessed altogether.
 
@@ -42,13 +42,13 @@ If you use [etke.cc/ansible](https://github.com/etkecc/ansible) and [matrix-dock
 matrix_synapse_allow_public_rooms_over_federation: false
 ```
 
-As enabling the option unfederates your homeserver, *nobody* outside of the homeserver, including a MRS instance, can access to it over federation, making it technically impossible to index the rooms as a matter of course.
+As enabling the option prevents your homeserver from publishing its public rooms directory over federation, *no other Matrix server*, including MRS instances, can access the directory, making it technically impossible to view/parse/index the public rooms as a matter of course.
 
 ### Add special strings to the room's topic
 
-If you do want to make the server itself federated and the room directory to be published over the federation, only preventing rooms from being indexed, you can add special strings which instruct MRS instances not to index them.
+If you do want to make your server publish the public rooms directory over the federation, only preventing rooms from being indexed by MRS instances specifically, you can add special string which instruct any MRS instance not to index them.
 
-As a room administrator/moderator, you can add these strings to the room topic to prevent indexing:
+As a room administrator/moderator, you can add that string to the room topic to prevent indexing:
 
 ```
 (MRS-noindex:true-MRS)


### PR DESCRIPTION
Please note that my knowledge about deindexing is limited to the current documentation, while I've tried my best to understand how it works.

- Emphasize that it is not possible for the MRS developers team to deindex rooms from instances
- Emphasize that indexing is conducted only based on publicly-available information